### PR TITLE
Require 'nanoc3' fails after upgrading to nanoc 3.3 

### DIFF
--- a/lib/nutils.rb
+++ b/lib/nutils.rb
@@ -8,7 +8,7 @@ module Nutils
 end
 
 # Load requirements
-require 'nanoc3'
+require 'nanoc'
 
 # Load nutils
 require 'nutils/base'


### PR DESCRIPTION
Require 'nanoc' seems to fix the issue.
